### PR TITLE
[World Builder Game Launch][1/2] Scope out frontend components to add for exposing endpoint

### DIFF
--- a/deploy/web/builderapp/src/components/WorldBuilderPage.js
+++ b/deploy/web/builderapp/src/components/WorldBuilderPage.js
@@ -42,6 +42,8 @@ function WorldBuilder({ upload }) {
   const world_name =
     state.dimensions.name == null ? " " : state.dimensions.name;
 
+  // TODO: Add the launch game button, should be next to name, or on bottom bar
+  // requires the state.dimensions.id, mb save first?
   //TODO: Consider moving the export somewhere else?
   return (
     <>

--- a/deploy/web/builderapp/src/components/WorldManager.js
+++ b/deploy/web/builderapp/src/components/WorldManager.js
@@ -246,6 +246,18 @@ function ListWorlds({ isOpen, setIsOverlayOpen }) {
     );
   }
 }
+/* Functions should:
+  1. Save the world - regardless of if it has been saved or not!
+  2. Pass the id to the game (hit the POST game/new) endpoint
+    - Should we include cool naming as jason suggested?  i.e url param for name?
+    - get url param from response
+  3. Surface the url param/link on the page
+      * might be judicious to impose some limit on number of launches a user gets per session
+*/
+export async function launchWorld(state){
+  // TODO: See above
+  return null;
+}
 
 export async function postWorld(state) {
   // can pretty much just take the dimensions and entities as is


### PR DESCRIPTION
## Overview

This PR is the first in the stack which adds frontend components for launching a game with a custom world from the world builder.

## Implementation

This design is to add a launch button on the bottom bar of the frontend which, when pressed:

- Saves or Updates the current world the user is editing

- Sends the id of the saved/updated world to the new game endpoint

- Receives back the game id for the new game instance

- Opens a new window with the id for the new game instance

## Next steps

Provide a concrete implementation for the button, and execute the end to end flow.