### PR TITLE
[Event Loggers][1/1] Enhance unit testing for event interaction loggers 

### DIFF
--- a/light/world/tests/test_loggers.py
+++ b/light/world/tests/test_loggers.py
@@ -139,7 +139,6 @@ class TestInteractionLoggers(unittest.TestCase):
             test_graph.to_json_rv(agent_node.get_room().node_id)
         )
 
-    # Test end_meta_episode - 2 test
     def test_end_meta_episode_room_logger(self):
         """
         Test calling end_meta_episode:
@@ -230,7 +229,6 @@ class TestInteractionLoggers(unittest.TestCase):
         self.assertEqual(len(logger.context_buffer), 0)
         self.assertEqual(logger.num_players_present, 0)
 
-    # Test observe event - 2 test, 2 for afk, 1 for before room
     def test_observer_event_goes_context_room_logger(self):
         """
         Test calling observe_event under normal circumstances adds the 


### PR DESCRIPTION
## Overview

This PR further adds unit testing for event loggers, as laid out in #37 

## Implementation

The branch adds 13 unit test, and unit testing for:

- The initial state of loggers

- The begin and end meta-episode methods of loggers

- Add player and remove player for room loggers

- Pre-player events in rooms going to context buffer

- AFK events interacting properly with the context buffer for loggers

- Observe event for loggers

And further moves the common graph setup to a helper function.

## Testing:
Running `python light/world/tests/test_loggers.py` returns:

```
..................
----------------------------------------------------------------------
Ran 18 tests in 0.057s

OK
```