### PR TITLE
[ModelSouls] Partner heuristic fixes

### DIFF
--- a/light/world/souls/models/partner_heuristic_model_soul.py
+++ b/light/world/souls/models/partner_heuristic_model_soul.py
@@ -400,7 +400,6 @@ class PartnerHeuristicModelSoul(ModelSoul):
                 and self.get_last_interaction_partner(partner) is None
             ):
                 self.set_interaction_partner(partner)
-                # TODO handle dialogue with no observation
                 self.npc_dialogue(None)
                 return
         else:


### PR DESCRIPTION
# Overview
To finish up on the soul introduced in #67, this PR adds heuristic attacking, as well as fixing a small bug in dialogue history raised by @klshuster.

# Testing
Found a bot to talk to in `play_random_map.py`, seemed active.