### PR TITLE
[Souls] Proper await syntax for observation

### DIFF
--- a/light/world/souls/soul.py
+++ b/light/world/souls/soul.py
@@ -42,14 +42,15 @@ class Soul(ABC):
         during a reap.
         """
         future_id = f"Node-{self.target_node.node_id}-obs-{time.time():.10f}"
-        self._observe_futures[future_id] = self.observe_event(event)
+        _observe_future = self.observe_event(event)
+        
 
         async def _await_observe_then_cleanup():
-            await self._observe_futures[future_id]
+            await _observe_future
             del self._observe_futures[future_id]
 
         loop = asyncio.get_running_loop()
-        asyncio.ensure_future(_await_observe_then_cleanup(), loop=loop)
+        self._observe_futures[future_id] = asyncio.ensure_future(_await_observe_then_cleanup(), loop=loop)
 
     @abstractmethod
     async def observe_event(self, event: "GraphEvent"):


### PR DESCRIPTION
# Overview
A similar bug to what was repaired in #67, we actually want to be `cancel`ing the result of the `asyncio` scheduling call, rather than the awaitable itself. This fixes reaping while an observe event is still active.

# Testing
Ran locally on server, didn't see any more exceptions about reap failures.