### PR TITLE
[Bugs] Ensuring line breaks in spoken messages, fix room swap partner clear

### DIFF
--- a/deploy/web/gameapp/src/styles.css
+++ b/deploy/web/gameapp/src/styles.css
@@ -154,6 +154,7 @@ a {
   animation: popInChat 0.25s cubic-bezier(0, 0.5, 0, 1);
   box-shadow: 0 2px 2px #bbb;
   text-align: left;
+  white-space: pre-line;
 }
 
 .message.type-action {

--- a/light/world/souls/models/partner_heuristic_model_soul.py
+++ b/light/world/souls/models/partner_heuristic_model_soul.py
@@ -345,7 +345,13 @@ class PartnerHeuristicModelSoul(ModelSoul):
         Get the last interaction partner labelled for the given node, if it exists
         """
         if hasattr(node, "_last_interaction_partner_id"):
-            return node._last_interaction_partner_id
+            last_partner_id = node._last_interaction_partner_id
+            if last_partner_id is None:
+                return None
+            last_partner_node = self.world.oo_graph.get_node(last_partner_id)
+            if last_partner_node.get_room() != node.get_room():
+                return None  # last partner is no longer present.
+            return last_partner_id
         else:
             return None
 


### PR DESCRIPTION
# Details
Fixing some bugs described in chat. 
- The css change ensures that line breaks will appear in model `DEBUG` text. 
- The soul change ensures that if an agent swaps rooms, they won't still be "attached" to their previous conversation partner unless that partner comes along as well.

# Testing:
![Screen Shot 2020-08-11 at 3 58 03 PM](https://user-images.githubusercontent.com/1276867/89942972-754d0200-dbeb-11ea-8cca-5e9e8ff8e7b8.png)
