### PR TITLE
Creating local cache of DB for json loading

### DIFF
--- a/scripts/examples/play_map.py
+++ b/scripts/examples/play_map.py
@@ -109,7 +109,7 @@ if opt["load_map"] != "none":
 else:
     StarspaceBuilder.add_parser_arguments(parser)
     opt, _unknown = parser.parse_and_process_known_args()
-    ldb = LIGHTDatabase(opt["light_db_file"])
+    ldb = LIGHTDatabase(opt["light_db_file"], read_only=True)
     world_builder = StarspaceBuilder(ldb, debug=False, opt=opt)
 
 if opt["use_models"] == "PartnerHeuristicModelSoul":


### PR DESCRIPTION
# Overview
Wraps the Database cache in a JSON dump such that future loads can come directly from file. Will only update the JSON if the database has changed or if there is no JSON.

# Usage
Initialize your `LIGHTDatabase` with `read_only=True` to initialize with a cache, and load from that cache in all future loads. Thanks to #94's fix of `get_id`, all loads on that database should be faster, but it will be impossible to write. Updated `play_map.py` as an example.