### PR TITLE
safe reset of convos

### DIFF
--- a/light/world/souls/base_soul.py
+++ b/light/world/souls/base_soul.py
@@ -52,15 +52,15 @@ class BaseSoul(Soul):
             text = event.text_content
             if not (text.startswith("DEBUG")):
                 agent._last_interaction_history.append(
-                    [(event_actor_id, event_name), text]
+                    [(event_actor_id, event_name, event.safe), text]
                 )
         if (agent_id == event_actor_id or partner_id == event_actor_id) and (
             event_name == "EmoteEvent"
         ):
             # log event
             text = event.text_content
-            agent._last_interaction_history.append(
-                [(event_actor_id, event_name), "*" + text + "*"]
+            agent._last_interaction_history.append(                
+                [(event_actor_id, event_name, True), "*" + text + "*"]
             )
         # Only log these kind of act events.
         act_events = [
@@ -205,6 +205,11 @@ class BaseSoul(Soul):
                 dtxt = dtxt.lstrip(" ")
                 dtxt += "\n" + d[1]
             turn_id = current_turn_id
+            is_safe = d[0][2]
+            if not is_safe:
+                # reset conversation when unsafe utterances are in the history
+                dtxt = ''
+        dtxt = dtxt.lstrip(' ')
         return txt + dtxt
 
     @classmethod


### PR DESCRIPTION
We might want something like this:  if something unsafe happens in the history, make the model reset its history (we do that in blenderbot). otherwise i noticed once something is unsafe, it keeps doing unsafe things afterwards?