### PR TITLE
on_use events are totally broken

### DIFF
--- a/light/graph/events/use_events.py
+++ b/light/graph/events/use_events.py
@@ -196,19 +196,20 @@ class UseEvent(GraphEvent):
         for i in range(len(on_uses)):
             on_use = on_uses[i]
 
-            remaining_uses = on_use["remaining_uses"]
-
-            if remaining_uses == "inf":
-                pass
-            elif remaining_uses > 0:
-                self.target_nodes[0].on_use[i]["remaining_uses"] = remaining_uses - 1
-            else:
-                # No remaining uses for this event
-                self.exit_message(world)
-                return
-
             constraints = on_use["constraints"]
             if self.satisfy_constraints(constraints, world):
+                if not ('remaining_uses' in on_use):
+                    # add missing field
+                    on_use["remaining_uses"] = "inf"
+                remaining_uses = on_use["remaining_uses"]
+                if remaining_uses == "inf":
+                    pass
+                elif remaining_uses > 0:
+                    self.target_nodes[0].on_use[i]["remaining_uses"] = remaining_uses - 1
+                else:
+                    # No remaining uses for this event
+                    self.exit_message(world)
+                    return
                 events = on_use["events"]
                 self.found_use = True
                 self.execute_events(events, world)
@@ -345,6 +346,16 @@ class UseEvent(GraphEvent):
             )
         return ErrorEvent(cls, actor, f"You don't have '{object_name}' to use.")
 
+    def exit_message(self, world):
+        event = {
+            "type": "broadcast_message",
+            "params": {
+                  "self_view": "Nothing special seems to happen."
+              }
+            }
+        events = [event]
+        self.execute_events(events, world)
+        
     @classmethod
     def construct_from_args(
         cls,

--- a/scripts/examples/simple_world.json
+++ b/scripts/examples/simple_world.json
@@ -266,7 +266,8 @@
       "node_id": "shovel_5_6",
       "object": true,
       "on_use": [
-        {
+          {
+          "remaining_uses": 1,
           "events": [
             {
               "type": "create_entity",


### PR DESCRIPTION
What a mess.
- the "remaining_uses" code was just crashing even the simple_world.json  test
- an exit "exit_message" function is just completely missing???
- even worse, the complex_world.json has not been converted to the new name changes, format 😠😠😠😠😠😠  e.g. it still has pre and post and well everything changed has not been changed (I have not done this in this PR.. this is work Eric absolutely should have done)
- not sure if a bug but I don't get this: why are there use_events.py  and use_triggered_events.py which both seem to define "class UseTriggeredEvent" ?
 
<img width="770" alt="Screen Shot 2021-04-30 at 7 14 08 AM" src="https://user-images.githubusercontent.com/11068664/116687784-b193de80-a983-11eb-94ee-089ba8b08651.png">
