### PR TITLE
fixed typo in minitutorial

### DIFF
--- a/deploy/web/landingapp/src/pages/LandingPage/index.js
+++ b/deploy/web/landingapp/src/pages/LandingPage/index.js
@@ -112,7 +112,7 @@ const LandingPage = (props) => {
                       <i>give tool to smithy</i>), wear clothing, wield weapons,
                       eat, drink, try to steal objects, and more. Type
                       <i> help </i>
-                      in game for the full flist of actions.
+                      in game for the full list of actions.
                     </p>
                   </>
                 ) : null}


### PR DESCRIPTION
Page 2 of the mini tutorial previously had helpin as one word now they read help in.
![image](https://user-images.githubusercontent.com/80718342/117157223-69fac180-ad8c-11eb-98c6-ee449a55a7d9.png)
