### PR TITLE
Creating a light world object from an instance of the old graph

### DIFF
--- a/light/world/world.py
+++ b/light/world/world.py
@@ -92,6 +92,7 @@ class World(object):
 
     @staticmethod
     def from_graph(graph, graph_builder=None):
+        """Loads the world from the older versions of graph."""
         world = World(graph._opt, graph_builder)
         world.oo_graph = OOGraph.from_graph(graph)
         world._node_freeze = graph._node_freeze


### PR DESCRIPTION
**Patch description**
Trying to load the old crowdsourced data, ran into problem with `World.from_graph` function. This provides a solution.
Note that this solution skips some of the information that was read from the graph object. The graph instances in the dataset did not have the removed values (neither did it converted `OOGraph`). It seems safe to remove them, specially because we are deprecating the use of old graph.

**How tested**

Previously, The following script was crashing. Now, it generates an instance of the game world.
```.py
import pickle
from light.world.world import World

with open('path/to/crowdsourced/dataset', 'rb') as fpi:
    data = pickle.load(fpi)

old_graph = data[0]['graph']  # picking one arbitrarily
world = World.from_graph(old_graph)
```