### PR TITLE
Mephisto LIGHT worker task

### DIFF
--- a/crowdsourcing/light_gameplay/utils.py
+++ b/crowdsourcing/light_gameplay/utils.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+
+"""
+Contains various utilities that make it easier to parse through the data
+and prepare it for processing.
+"""
+
+
+def get_spawns(dialogue_data):
+    spawns = []
+
+    for turn in dialogue_data:
+        text = turn["text"].strip()
+        if turn["caller"] == "SoulSpawnEvent":
+            spawns.append(text)
+    
+    return spawns
+
+
+def was_tutorial(dialogue_data):
+    spawns = get_spawns(dialogue_data)
+    return (
+        "You are, well, yourself... a wandering soul who has yet to become someone in the full LIGHT "
+        "world. Perhaps you may be granted admission by the dungeon master?"
+    ) in "\n".join(spawns)
+
+
+def had_full_game(dialogue_data):
+    spawns = get_spawns(dialogue_data)
+    spawn_string = "\n".join(spawns)
+    NON_TUTORIAL_INIT_REGEX = '(?!.*  You\.)Your soul possesses (.*?). Roleplay well, my friend, and earn experience points!'
+    for line in spawn_string.split('\n'):
+        if bool(re.match(NON_TUTORIAL_INIT_REGEX, line)):
+            return True
+    return False

--- a/crowdsourcing/light_gameplay/view_results.py
+++ b/crowdsourcing/light_gameplay/view_results.py
@@ -8,6 +8,7 @@ from mephisto.abstractions.databases.local_database import LocalMephistoDB
 from mephisto.tools.examine_utils import run_examine_or_review, print_results
 from mephisto.data_model.worker import Worker
 from light.colors import Colors as C
+from utils import was_tutorial, had_full_game
 
 db = LocalMephistoDB()
 
@@ -17,7 +18,7 @@ def format_data_for_printing(data):
     duration = data["task_end"] - data["task_start"]
     metadata_string = (
         f"Worker: {worker_name}\nUnit: {data['unit_id']}\n"
-        f"Duration: {int(duration)}\nStatus: {data['status']}\n"
+        f"Duration: {int(duration) / 60.0}\nStatus: {data['status']}\n"
     )
 
     dialogue_string = ""
@@ -49,9 +50,21 @@ def format_data_for_printing(data):
             text = text.replace("\n", "\n    ")
             dialogue_string += f"  {C.PURPLE}{text}{C.RESET}\n"
 
+    dialogue_had_tutorial = was_tutorial(dialogue_data)
+    dialogue_had_full_game = had_full_game(dialogue_data)
+    episode_type = f"{C.BOLD_PURPLE}UNKNOWN{C.RESET}"
+    if dialogue_had_tutorial:
+        if dialogue_had_full_game:
+            episode_type = f"{C.BOLD_GREEN}COMPELTED TUTORIAL{C.RESET}"
+        else:
+            episode_type = f"{C.BOLD_RED}FAILED TUTORIAL{C.RESET}"
+    elif dialogue_had_full_game:
+        episode_type = f"{C.BOLD_BLUE}RETURNING WORKER{C.RESET}"
+         
     return (
         f"{metadata_string}"
         f"Says: {says}, Dos: {dos}\n"
+        f"Type: {episode_type}\n"
         f"Feedback: {feedback}\n\n"
         f"{dialogue_string}-----------\n\n"
     )

--- a/crowdsourcing/light_gameplay/webapp/src/Views/OnboardingView/styles.css
+++ b/crowdsourcing/light_gameplay/webapp/src/Views/OnboardingView/styles.css
@@ -1,6 +1,7 @@
 .onboarding-container{
     height: 100vh;
     width: 100vw;
+    overflow-y: scroll;
 }
 .onboarding-body {
     display: flex;

--- a/crowdsourcing/light_gameplay/webapp/src/components/Forms/RadioForm/CheckBoxAnswer/index.js
+++ b/crowdsourcing/light_gameplay/webapp/src/components/Forms/RadioForm/CheckBoxAnswer/index.js
@@ -3,7 +3,7 @@ import React, {useState, useEffect} from "react";
 /* STYLES */
 import "./styles.css";
 /* BOOTSTRAP COMPONENTS */
-import Form from 'react-bootstrap/form';
+import Form from 'react-bootstrap/Form';
 /* CUSTOM COMPONENTS */
 import ChatInputOption from "../../../ChatInputOption";
 

--- a/crowdsourcing/light_gameplay/webapp/src/components/Forms/RadioForm/index.js
+++ b/crowdsourcing/light_gameplay/webapp/src/components/Forms/RadioForm/index.js
@@ -3,7 +3,7 @@ import React, {useState, useEffect} from "react";
 /* STYLES */
 import "./styles.css";
 /* BOOTSTRAP COMPONENTS */
-import Form from 'react-bootstrap/form';
+import Form from 'react-bootstrap/Form';
 /* CUSTOM COMPONENTS */
 import CheckBoxAnswer from "./CheckBoxAnswer"
 


### PR DESCRIPTION
# Overview
Following up on #282, this PR updates the task frontend introduced in #281 to now be in a Mephisto-task format. Note, this now requires using Mephisto version 1.0.0.

# Implementation
Due to how Mephisto tasks build, I had to rearrange a number of folders, configure webpack, change react versions, etc. to get things running. That's _most_ of the churn of this PR. Additionally:
- Replaces the `AppRouter` component with a `LIGHTAppTaskFrame` component, which does the type of routing that a Mephisto task expects. This component is also responsible for requesting the correct authorization key for a given worker, and passing the synthesized URL to the underlying task component.
- Updates the `Task` component to receive a passed URL and the submit function, though the latter is currently unused right now.
- Creates the Mephisto `run_task.py` script that actually launches the mephisto job, requiring a `preauth_secret` that needs to be shared between the server launch and the Mephisto task. This allows Mephisto to sign the worker's auth token properly.

Some notes here, I've left a few messy components in the `LIGHTAppTaskFrame` file. These should probably be refactored out. Also unfortunately @JustinPinero I expect there to be a significant amount of manual churn merging your onboarding flow, considering some fairly substantial folder thrash required to get Mephisto up-and-running. When you merge onboarding into this, you'll have to add an `onboarding_qualification` to the `local` yaml configuration in order to see your onboarding view (after you insert it in the `isOnboarding` branch of `LIGHTAppTaskFrame`).  See the `local_test.yaml` file in `crowdsourcing/dialogues/multi_party_chat/hydra_confs` folder for an example.

# Testing
```
terminal 1>/Users/jju/LIGHT/deploy/web> ./deploy.sh local-no-models rebuild-task
terminal 2>/Users/jju/LIGHT/crowdsourcing/light_gameplay> python run_task.py 
``` 
Navigate to the desired location:
![Screen Shot 2022-03-25 at 4 41 33 PM](https://user-images.githubusercontent.com/1276867/160207238-d9cda31a-1bc2-4514-8ff3-705658989dd2.png)

