### PR TITLE
Reducing model space for deploy

### DIFF
--- a/deploy/web/server/game_instance.py
+++ b/deploy/web/server/game_instance.py
@@ -13,6 +13,9 @@ from light.world.souls.repeat_soul import RepeatSoul
 from light.world.souls.models.generative_heuristic_model_soul import (
     GenerativeHeuristicModelSoul,
 )
+from light.world.souls.models.tutorial_model_soul import (
+    TutorialModelSoul,
+)
 
 import os.path
 import time
@@ -185,10 +188,12 @@ class TutorialInstance(GameInstance):
         self._should_shutdown = False
         self._did_complete = True
 
-    def fill_souls(self, _FLAGS, _model_resources):
+    def fill_souls(self, _FLAGS, model_resources):
         """Tutorials directly register the tutorial to the DM"""
         self.world.purgatory.register_filler_soul_provider(
-            "tutorial", RepeatSoul, lambda: []
+            "tutorial",
+            TutorialModelSoul,
+            lambda: [model_resources["shared_model_content"]],
         )
         dm_agent = list(self.world.oo_graph.agents.values())[1]
         assert dm_agent.name == "Dungeon Master", "Did not find DM!"

--- a/light/world/action_parser.py
+++ b/light/world/action_parser.py
@@ -108,6 +108,7 @@ class ActionParser:
         self.agent.opt.log()
         # Lock to handle concurrency, fixed better with asycio
         self.parse_lock = threading.Condition()
+        opt["_action_parser"] = self
 
     def parse(self, txt, actor=None):
         if self.agent is None:

--- a/light/world/souls/models/generative_heuristic_model_soul.py
+++ b/light/world/souls/models/generative_heuristic_model_soul.py
@@ -61,35 +61,14 @@ class GenerativeHeuristicModelSoul(OnEventSoul):
         """
         Load up the dialog model for use with this class
         """
-        # Model args if no reranking
-        # dialog_args = [
-        #     "-dt",
-        #     "valid",
-        #     "--inference",
-        #     "beam",
-        #     "--beam-context-block-ngram",
-        #     "3",
-        #     "--beam-block-ngram",
-        #     "3",
-        #     "--beam-size",
-        #     "10",
-        #     "--beam-min-length",
-        #     "20",
-        #     "-m",
-        #     "transformer/generator",
-        #     "-mf",
-        #     dialog_model_path,
-        # ]
-
         # Reranker args
         dialog_args = [
             "-m",
-            "internal:light_whoami/generative_rerank",
+            "projects.light_whoami.agents.expanded_attention:ExpandedDecoderAttentionAndPacerAgent",
             "--predictor-model-file",
-            # "/home/ubuntu/data/models/rerank/model",
-            "/checkpoint/kshuster/projects/continual_learning/light_whoami/whoami_sweep3b_Tue_Oct_13/943/model",
+            "zoo:light_whoami/rpa_reranker/model",
             "--inference",
-            "delayedbeam",
+            "beam",
             "-dt",
             "valid",
             "--beam-context-block-ngram",
@@ -108,11 +87,10 @@ class GenerativeHeuristicModelSoul(OnEventSoul):
         dialog_opt["override"] = {
             "inference": "beam",
             "beam_context_block_ngram": 3,
-            "beam_size": 2,
+            "beam_size": 10,
             "beam_min_length": 20,
+            "model": "projects.light_whoami.agents.expanded_attention:ExpandedDecoderAttentionAndPacerAgent",
         }
-        # dialog_opt['override']['inference'] = 'topk'
-        # dialog_opt['override']['topk'] = 40
         return create_agent(dialog_opt, requireModelExists=True)
 
     @classmethod
@@ -124,7 +102,6 @@ class GenerativeHeuristicModelSoul(OnEventSoul):
         """
         Load up and create possible shared models for use with this class
         """
-        # TODO refactor with some kind of model-loading standard for model souls?
         from parlai.core.params import ParlaiParser
         from parlai.core.agents import create_agent
 
@@ -136,6 +113,7 @@ class GenerativeHeuristicModelSoul(OnEventSoul):
         )
 
         if act_model_path is not None:
+            # TODO @Kurt do we have an action model in character? Or just dialogue?
             # Load action model
             args = [
                 "-mf",

--- a/light/world/world.py
+++ b/light/world/world.py
@@ -83,7 +83,10 @@ class World(object):
         init_magic(self.opt.get("magic_db_path", "/scratch/light/data/magic.db"))
 
         # Set up action parser.
-        self.action_parser = ActionParser(opt)
+
+        self.action_parser = opt.get["_action_parser"]
+        if self.action_parser is None:
+            self.action_parser = ActionParser(opt)
 
     @staticmethod
     def from_graph(graph, graph_builder=None):


### PR DESCRIPTION
Adding tutorials showed that we were using more models than we necessarily had space for. This change reuses the `ActionParser` across all instances to ensure we don't reload it.