### PR TITLE
Running light task

### DIFF
--- a/light/modeling/tasks/atomic/build.py
+++ b/light/modeling/tasks/atomic/build.py
@@ -5,13 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-from glob import glob
 from parlai.utils.misc import msg_to_str
 import random
-import itertools
 import pandas as pd
 import json
-import time
 import shutil
 import light.modeling.tasks.utils as utils
 from light.data_model.light_database import LIGHTDatabase
@@ -23,7 +20,6 @@ import json
 import random
 import math
 import torch
-import numpy as np
 
 from tqdm import tqdm
 import torch.nn as nn

--- a/light/modeling/tasks/atomic/build.py
+++ b/light/modeling/tasks/atomic/build.py
@@ -26,9 +26,15 @@ import torch
 import numpy as np
 
 from tqdm import tqdm
-from fitbert import FitBert
 import torch.nn as nn
 import string
+
+IMPORTED_FITBERT = False
+try:
+    from fitbert import FitBert
+    IMPORTED_FITBERT = True
+except ImportError:
+    pass
 
 RESOURCES = [
     DownloadableFile(
@@ -436,6 +442,7 @@ def build_atomic(dpath, odpath, opt):
         # TODO finetune a BERT for LIGHT
         # BLM = pytorch_pretrained_bert.BertForMaskedLM.from_pretrained(model_name)
         # fitbert = FitBert(model=BLM)
+        assert IMPORTED_FITBERT, "You need to have FitBert installed manually to use this task."
         fitbert = FitBert()
         fitbert.bert = nn.DataParallel(fitbert.bert)
 


### PR DESCRIPTION
# Patch description
* Running the `light` cli was crashing due to *FitBert* not being installed. The imports it only if it is needed.
* Some minor clean ups.

# Extra notes
My first approach was trying to add FitBert to the requirements. But it has some unresolvable dependency with some other packages; I eventually gave up on that effort. During that I tried many clean installs of LIGHT and it looks the install is a bit shaky.  For example, this happens at the end of the current installs (python 3.8)
<img width="1254" alt="Screenshot 2023-03-12 at 8 39 40 PM" src="https://user-images.githubusercontent.com/11262163/224585128-866bfd8d-3674-4615-97f9-fea8023f1509.png">


