### PR TITLE
OneRoomGraphBuilder update

### DIFF
--- a/light/data_model/db/base.py
+++ b/light/data_model/db/base.py
@@ -6,8 +6,8 @@
 
 
 from abc import ABC, abstractmethod
-from omegaconf import MISSING, DictConfig
-from sqlalchemy import create_engine
+from omegaconf import MISSING, DictConfig  # type: ignore
+from sqlalchemy import create_engine  # type: ignore
 from enum import Enum
 from typing import Optional, Union, Dict, Any, Type
 from uuid import uuid4
@@ -17,7 +17,7 @@ import shutil
 import os
 import json
 
-from hydra.core.config_store import ConfigStore
+from hydra.core.config_store import ConfigStore  # type: ignore
 
 DEFAULT_LOG_PATH = "".join(
     [os.path.abspath(os.path.dirname(__file__)), "/../../../logs"]
@@ -120,8 +120,8 @@ class BaseDB(ABC):
             self.engine = create_engine(f"sqlite:////{db_path}")
         elif config.backend == "aws-postgres":
             try:
-                import psycopg2
-                import boto3
+                import psycopg2  # type: ignore
+                import boto3  # type: ignore
             except ImportError:
                 print(
                     "For aws-postgres usage, you must also `pip install mysqlclient boto3 psycopg2-binary"
@@ -176,7 +176,7 @@ class BaseDB(ABC):
             full_path = os.path.join(self.file_root, file_path)
             return os.path.exists(full_path)
         elif self.backend in ["aws-postgres"]:
-            import botocore
+            import botocore  # type: ignore
 
             try:
                 self.bucket.Object(file_path).load()
@@ -205,6 +205,7 @@ class BaseDB(ABC):
                 if json_encode:
                     json.dump(data, target_file)
                 else:
+                    assert isinstance(data, str), "Must use JsonEncode for non-strings"
                     target_file.write(data)
         elif self.backend in ["aws-postgres"]:
             if json_encode:

--- a/light/data_model/db/environment.py
+++ b/light/data_model/db/environment.py
@@ -7,7 +7,7 @@
 from light.data_model.db.base import BaseDB, DBStatus, DBSplitType, HasDBIDMixin
 from light.data_model.db.users import DBPlayer
 from light.graph.structured_graph import OOGraph
-from omegaconf import MISSING, DictConfig
+from omegaconf import MISSING, DictConfig  # type: ignore
 from typing import (
     Optional,
     List,
@@ -20,7 +20,7 @@ from typing import (
     cast,
     TYPE_CHECKING,
 )
-from sqlalchemy import (
+from sqlalchemy import (  # type: ignore
     insert,
     select,
     Enum,
@@ -32,8 +32,8 @@ from sqlalchemy import (
     Boolean,
     UniqueConstraint,
 )
-from sqlalchemy.orm import declarative_base, relationship, Session, join
-import sqlalchemy.exc
+from sqlalchemy.orm import declarative_base, relationship, Session, join  # type: ignore
+import sqlalchemy.exc  # type: ignore
 
 import enum
 import os
@@ -70,10 +70,10 @@ class DBNameKey(HasDBIDMixin):
     id and a name
     """
 
-    db_id = Column(String(ID_STRING_LENGTH), primary_key=True)
-    name = Column(String(BASE_NAME_LENGTH_CAP), nullable=False, index=True, unique=True)
-    status = Column(Enum(DBStatus), nullable=False, index=True)
-    split = Column(Enum(DBSplitType), nullable=False, index=True)
+    db_id: str = Column(String(ID_STRING_LENGTH), primary_key=True)  # type: ignore
+    name: str = Column(String(BASE_NAME_LENGTH_CAP), nullable=False, index=True, unique=True)  # type: ignore
+    status: DBStatus = Column(Enum(DBStatus), nullable=False, index=True)  # type: ignore
+    split: DBSplitType = Column(Enum(DBSplitType), nullable=False, index=True)  # type: ignore
 
 
 class DBAgentName(DBNameKey, SQLBase):
@@ -121,12 +121,12 @@ class DBRoomName(DBNameKey, SQLBase):
 class DBElem(HasDBIDMixin):
     """Class for shared attributes for all graph model components"""
 
-    db_id = Column(String(ID_STRING_LENGTH), primary_key=True)
-    name = Column(String(BASE_NAME_LENGTH_CAP), nullable=False, index=True)
-    built_occurrences = Column(Integer, nullable=False, default=0)
-    status = Column(Enum(DBStatus), nullable=False, index=True)
-    create_timestamp = Column(Float, nullable=False)
-    creator_id = Column(
+    db_id: str = Column(String(ID_STRING_LENGTH), primary_key=True)  # type: ignore
+    name: str = Column(String(BASE_NAME_LENGTH_CAP), nullable=False, index=True)  # type: ignore
+    built_occurrences: int = Column(Integer, nullable=False, default=0)  # type: ignore
+    status: DBStatus = Column(Enum(DBStatus), nullable=False, index=True)  # type: ignore
+    create_timestamp: float = Column(Float, nullable=False)  # type: ignore
+    creator_id: str = Column(  # type: ignore
         String(ID_STRING_LENGTH)
     )  # temp retain the creator ID for new things
 
@@ -226,24 +226,34 @@ class DBAgent(DBElem, SQLBase):
     )
     ID_PREFIX = "AGE"
 
-    base_id: str = Column(ForeignKey("agent_names.db_id"), nullable=False)
-    persona = Column(String(PERSONA_LENGTH_CAP), nullable=False, index=True)
-    physical_description = Column(
+    base_id: str = Column(ForeignKey("agent_names.db_id"), nullable=False)  # type: ignore
+    persona: str = Column(String(PERSONA_LENGTH_CAP), nullable=False, index=True)  # type: ignore
+    physical_description: str = Column(  # type: ignore
         String(DESCRIPTION_LENGTH_CAP), nullable=False, index=True
     )
-    name_prefix = Column(String(NAME_PREFIX_LENGTH), nullable=False)
-    is_plural = Column(Boolean)
-    size = Column(Integer)
-    contain_size = Column(Integer)
-    constitution = Column(Float)
-    charisma = Column(Float)
-    strength = Column(Float)
-    dexterity = Column(Float)
-    intelligence = Column(Float)
-    wisdom = Column(Float)
-    base_name: List["DBAgent"] = relationship(
+    name_prefix: str = Column(String(NAME_PREFIX_LENGTH), nullable=False)  # type: ignore
+    is_plural: bool = Column(Boolean)  # type: ignore
+    size: int = Column(Integer)  # type: ignore
+    contain_size: int = Column(Integer)  # type: ignore
+    constitution: float = Column(Float)  # type: ignore
+    charisma: float = Column(Float)  # type: ignore
+    strength: float = Column(Float)  # type: ignore
+    dexterity: float = Column(Float)  # type: ignore
+    intelligence: float = Column(Float)  # type: ignore
+    wisdom: float = Column(Float)  # type: ignore
+    base_name: "DBAgentName" = relationship(
         "DBAgentName", backref="agents", foreign_keys=[base_id]
     )
+
+    def character_features(self, globalFull: bool, full: bool = False) -> str:
+        """Get text feature for a db agent (for model use)"""
+        if globalFull:
+            full = True
+        str = ""
+        str += self.name
+        if full:
+            str += f". {self.persona} "
+        return str.rstrip()
 
     def __repr__(self):
         return f"DBAgent({self.db_id!r}| {self.name})"
@@ -261,26 +271,36 @@ class DBObject(DBElem, SQLBase):
     )
     ID_PREFIX = "OBE"
 
-    base_id: str = Column(ForeignKey("object_names.db_id"), nullable=False)
+    base_id: str = Column(ForeignKey("object_names.db_id"), nullable=False)  # type: ignore
     physical_description = Column(
         String(DESCRIPTION_LENGTH_CAP), nullable=False, index=True
     )
-    is_container = Column(Float)
-    is_drink = Column(Float)
-    is_food = Column(Float)
-    is_gettable = Column(Float)
-    is_surface = Column(Float)
-    is_wearable = Column(Float)
-    is_weapon = Column(Float)
-    name_prefix = Column(String(NAME_PREFIX_LENGTH), nullable=False)
-    is_plural = Column(Boolean)
-    size = Column(Integer)
-    contain_size = Column(Integer)
-    value = Column(Float)
-    rarity = Column(Float)
-    base_name: List["DBObject"] = relationship(
+    is_container: float = Column(Float)  # type: ignore
+    is_drink: float = Column(Float)  # type: ignore
+    is_food: float = Column(Float)  # type: ignore
+    is_gettable: float = Column(Float)  # type: ignore
+    is_surface: float = Column(Float)  # type: ignore
+    is_wearable: float = Column(Float)  # type: ignore
+    is_weapon: float = Column(Float)  # type: ignore
+    name_prefix: str = Column(String(NAME_PREFIX_LENGTH), nullable=False)  # type: ignore
+    is_plural: bool = Column(Boolean)  # type: ignore
+    size: int = Column(Integer)  # type: ignore
+    contain_size: int = Column(Integer)  # type: ignore
+    value: float = Column(Float)  # type: ignore
+    rarity: float = Column(Float)  # type: ignore
+    base_name: "DBObjectName" = relationship(
         "DBObjectName", backref="objects", foreign_keys=[base_id]
     )
+
+    def object_features(self, globalFull: bool, full: bool = False):
+        """Get text feature for a dbobject"""
+        if globalFull:
+            full = True
+        str = ""
+        str += self.name
+        if full:
+            str += f". {self.physical_description} "
+        return str.rstrip()
 
     def __repr__(self):
         return f"DBObject({self.db_id!r}| {self.name})"
@@ -313,15 +333,25 @@ class DBRoom(DBElem, SQLBase):
     )
     ID_PREFIX = "RME"
 
-    base_id: str = Column(ForeignKey("room_names.db_id"), nullable=False)
-    description = Column(String(DESCRIPTION_LENGTH_CAP), nullable=False, index=True)
-    backstory = Column(String(DESCRIPTION_LENGTH_CAP), nullable=False, index=True)
-    size = Column(Integer)
-    indoor_status = Column(Enum(DBRoomInsideType), nullable=False)
-    rarity = Column(Float)
-    base_name: List["DBRoom"] = relationship(
+    base_id: str = Column(ForeignKey("room_names.db_id"), nullable=False)  # type: ignore
+    description: str = Column(String(DESCRIPTION_LENGTH_CAP), nullable=False, index=True)  # type: ignore
+    backstory: str = Column(String(DESCRIPTION_LENGTH_CAP), nullable=False, index=True)  # type: ignore
+    size: int = Column(Integer)  # type: ignore
+    indoor_status: DBRoomInsideType = Column(Enum(DBRoomInsideType), nullable=False)  # type: ignore
+    rarity: float = Column(Float)  # type: ignore
+    base_name: "DBRoomName" = relationship(
         "DBRoomName", backref="rooms", foreign_keys=[base_id]
     )
+
+    def room_features(self, globalFull: bool, full: bool = False):
+        """Get text feature for a DBRoom"""
+        if globalFull:
+            full = True
+        str = ""
+        str += self.name
+        if full:
+            str += f". {self.base_name}. {self.description} {self.backstory}"
+        return str.rstrip()
 
     def __repr__(self):
         return f"DBRoom({self.db_id!r}| {self.name})"
@@ -340,11 +370,11 @@ class DBNodeAttribute(HasDBIDMixin, SQLBase):
     )
     ID_PREFIX = "ATT"
 
-    db_id = Column(String(ID_STRING_LENGTH), primary_key=True)
-    target_id = Column(String(ID_STRING_LENGTH), nullable=False, index=True)
-    attribute_name = Column(String(EDGE_LABEL_LENGTH_CAP), nullable=False, index=True)
-    attribute_value_string = Column(String(EDGE_LABEL_LENGTH_CAP), nullable=False)
-    status: DBStatus = Column(Enum(DBStatus), nullable=False, index=True)
+    db_id: str = Column(String(ID_STRING_LENGTH), primary_key=True)  # type: ignore
+    target_id: str = Column(String(ID_STRING_LENGTH), nullable=False, index=True)  # type: ignore
+    attribute_name: str = Column(String(EDGE_LABEL_LENGTH_CAP), nullable=False, index=True)  # type: ignore
+    attribute_value_string: str = Column(String(EDGE_LABEL_LENGTH_CAP), nullable=False)  # type: ignore
+    status: DBStatus = Column(Enum(DBStatus), nullable=False, index=True)  # type: ignore
     creator_id = Column(
         String(ID_STRING_LENGTH)
     )  # temp retain the creator ID for new things
@@ -372,13 +402,13 @@ class DBEdgeType(enum.Enum):
 class DBEdgeBase(HasDBIDMixin):
     """Base attributes for an edge as stored in the environment DB"""
 
-    db_id = Column(String(ID_STRING_LENGTH), primary_key=True)
-    parent_id = Column(String(ID_STRING_LENGTH), nullable=False)
-    edge_type = Column(Enum(DBEdgeType), nullable=False)
-    status = Column(Enum(DBStatus), nullable=False, index=True)
-    edge_label = Column(String(EDGE_LABEL_LENGTH_CAP), nullable=False)
-    create_timestamp = Column(Float, nullable=False)
-    creator_id = Column(
+    db_id: str = Column(String(ID_STRING_LENGTH), primary_key=True)  # type: ignore
+    parent_id: str = Column(String(ID_STRING_LENGTH), nullable=False)  # type: ignore
+    edge_type: DBEdgeType = Column(Enum(DBEdgeType), nullable=False)  # type: ignore
+    status: DBStatus = Column(Enum(DBStatus), nullable=False, index=True)  # type: ignore
+    edge_label: str = Column(String(EDGE_LABEL_LENGTH_CAP), nullable=False)  # type: ignore
+    create_timestamp: float = Column(Float, nullable=False)  # type: ignore
+    creator_id: str = Column(  # type: ignore
         String(ID_STRING_LENGTH)
     )  # temp retain the creator ID for new things
 
@@ -394,8 +424,8 @@ class DBEdge(DBEdgeBase, SQLBase):
     )
     ID_PREFIX = "NED"
 
-    child_id = Column(String(ID_STRING_LENGTH), nullable=False)
-    built_occurrences = Column(Integer, nullable=False, default=0)
+    child_id: str = Column(String(ID_STRING_LENGTH), nullable=False)  # type: ignore
+    built_occurrences: int = Column(Integer, nullable=False, default=0)  # type: ignore
 
     _child: Optional[DBElem] = None
 
@@ -519,13 +549,13 @@ class DBFlag(HasDBIDMixin, SQLBase):
     __tablename__ = "flags"
     ID_PREFIX = "FLG"
 
-    db_id = Column(String(ID_STRING_LENGTH), primary_key=True)
-    flag_type = Column(Enum(DBFlagTargetType), nullable=False)
-    user_id = Column(String(ID_STRING_LENGTH), nullable=False, index=True)
-    target_id = Column(String(ID_STRING_LENGTH), nullable=False, index=True)
-    reason = Column(String(REPORT_REASON_LENGTH))
-    status = Column(Enum(DBStatus), nullable=False, index=True)
-    create_timestamp = Column(Float, nullable=False)
+    db_id: str = Column(String(ID_STRING_LENGTH), primary_key=True)  # type: ignore
+    flag_type: DBFlagTargetType = Column(Enum(DBFlagTargetType), nullable=False)  # type: ignore
+    user_id: str = Column(String(ID_STRING_LENGTH), nullable=False, index=True)  # type: ignore
+    target_id: str = Column(String(ID_STRING_LENGTH), nullable=False, index=True)  # type: ignore
+    reason: str = Column(String(REPORT_REASON_LENGTH))  # type: ignore
+    status: DBStatus = Column(Enum(DBStatus), nullable=False, index=True)  # type: ignore
+    create_timestamp: float = Column(Float, nullable=False)  # type: ignore
 
     def __repr__(self):
         return f"DBFlag({self.db_id!r}| {self.target_id}-{self.flag_type})"
@@ -544,21 +574,21 @@ class DBQuest(SQLBase, HasDBIDMixin):
     __tablename__ = "quests"
     ID_PREFIX = "QST"
 
-    db_id = Column(String(ID_STRING_LENGTH), primary_key=True)
-    agent_id: str = Column(ForeignKey("agents.db_id"), nullable=False)
-    parent_id: Optional[str] = Column(
+    db_id: str = Column(String(ID_STRING_LENGTH), primary_key=True)  # type: ignore
+    agent_id: str = Column(ForeignKey("agents.db_id"), nullable=False)  # type: ignore
+    parent_id: Optional[str] = Column(  # type: ignore
         ForeignKey("quests.db_id")
     )  # Map to possible parent
-    text_motivation = Column(String(QUEST_MOTIVATION_LENGTH), nullable=False)
-    target_type = Column(Enum(DBQuestTargetType), nullable=False)
-    target = Column(String(QUEST_MOTIVATION_LENGTH))
-    status = Column(Enum(DBStatus), nullable=False, index=True)
-    origin_filepath = Column(String(FILE_PATH_LENGTH_CAP))
-    position = Column(Integer)  # If subgoal of a parent, which substep?
-    creator_id = Column(
+    text_motivation: str = Column(String(QUEST_MOTIVATION_LENGTH), nullable=False)  # type: ignore
+    target_type: DBQuestTargetType = Column(Enum(DBQuestTargetType), nullable=False)  # type: ignore
+    target: str = Column(String(QUEST_MOTIVATION_LENGTH))  # type: ignore
+    status: DBStatus = Column(Enum(DBStatus), nullable=False, index=True)  # type: ignore
+    origin_filepath: str = Column(String(FILE_PATH_LENGTH_CAP))  # type: ignore
+    position: int = Column(Integer)  # type: ignore If subgoal of a parent, which substep?
+    creator_id: str = Column(  # type: ignore
         String(ID_STRING_LENGTH)
     )  # temp retain the creator ID for new things
-    create_timestamp = Column(Float, nullable=False)
+    create_timestamp: float = Column(Float, nullable=False)  # type: ignore
 
     _subgoals: Optional[List["DBQuest"]] = None
     _parent_chain: Optional[List["DBQuest"]] = None
@@ -607,8 +637,8 @@ class DBQuest(SQLBase, HasDBIDMixin):
             curr_item = parent_item
         parent_chain = list(reversed(parent_chain))
 
-        self._parent_chain = parent_chain
-        return parent_chain
+        self._parent_chain = parent_chain  # type: ignore
+        return parent_chain  # type: ignore
 
     def load_relations(self, db: "EnvDB") -> None:
         """Expand the parent chain and subgoals for this item"""
@@ -634,14 +664,14 @@ class DBGraph(SQLBase, HasDBIDMixin):
     __tablename__ = "saved_graphs"
     ID_PREFIX = "UGR"
 
-    db_id = Column(String(ID_STRING_LENGTH), primary_key=True)
-    graph_name = Column(String(WORLD_NAME_LENGTH_CAP), nullable=False, index=True)
-    creator_id = Column(
+    db_id: str = Column(String(ID_STRING_LENGTH), primary_key=True)  # type: ignore
+    graph_name: str = Column(String(WORLD_NAME_LENGTH_CAP), nullable=False, index=True)  # type: ignore
+    creator_id: str = Column(  # type: ignore
         String(ID_STRING_LENGTH), nullable=False, index=True
     )  # retain the creator ID, they own this
-    file_path = Column(String(FILE_PATH_LENGTH_CAP), nullable=False)
-    status = Column(Enum(DBStatus), nullable=False, index=True)
-    create_timestamp = Column(Float, nullable=False)
+    file_path: str = Column(String(FILE_PATH_LENGTH_CAP), nullable=False)  # type: ignore
+    status: DBStatus = Column(Enum(DBStatus), nullable=False, index=True)  # type: ignore
+    create_timestamp: float = Column(Float, nullable=False)  # type: ignore
 
     def get_graph(self, db: "EnvDB") -> OOGraph:
         """Get an OOGraph for this DBGraph, loading from file"""
@@ -782,7 +812,7 @@ class EnvDB(BaseDB):
                 return name_keys
             stmt = select(KeyClass)
             if name is not None:
-                stmt = stmt.where(KeyClass.name.like(f"%{name}%"))
+                stmt = stmt.where(KeyClass.name.like(f"%{name}%"))  # type: ignore
             if status is not None:
                 stmt = stmt.where(KeyClass.status == status)
             if split is not None:
@@ -949,12 +979,12 @@ class EnvDB(BaseDB):
         if base_id is not None:
             stmt = stmt.where(DBAgent.base_id == base_id)
         if name is not None:
-            stmt = stmt.where(DBAgent.name.like(f"%{name}%"))
+            stmt = stmt.where(DBAgent.name.like(f"%{name}%"))  # type: ignore
         if persona is not None:
-            stmt = stmt.where(DBAgent.persona.like(f"%{persona}%"))
+            stmt = stmt.where(DBAgent.persona.like(f"%{persona}%"))  # type: ignore
         if physical_description is not None:
             stmt = stmt.where(
-                DBAgent.physical_description.like(f"%{physical_description}%")
+                DBAgent.physical_description.like(f"%{physical_description}%")  # type: ignore
             )
         if name_prefix is not None:
             stmt = stmt.where(DBAgent.name_prefix == name_prefix)
@@ -964,7 +994,7 @@ class EnvDB(BaseDB):
             stmt = stmt.where(DBAgent.status == status)
         if split is not None:
             # Need to join up to parent for split query
-            stmt = stmt.where(DBAgent.base_name.has(split=split))
+            stmt = stmt.where(DBAgent.base_name.has(split=split))  # type: ignore
         if creator_id is not None:
             stmt = stmt.where(DBAgent.creator_id == creator_id)
 
@@ -1107,9 +1137,9 @@ class EnvDB(BaseDB):
         # Construct query
         stmt = select(DBObject)
         if base_id is not None:
-            stmt = stmt.where(DBObject.base_id.like(f"%{base_id}%"))
+            stmt = stmt.where(DBObject.base_id.like(f"%{base_id}%"))  # type: ignore
         if name is not None:
-            stmt = stmt.where(DBObject.name.like(f"%{name}%"))
+            stmt = stmt.where(DBObject.name.like(f"%{name}%"))  # type: ignore
         if physical_description is not None:
             stmt = stmt.where(
                 DBObject.physical_description.like(f"%{physical_description}%")
@@ -1157,7 +1187,7 @@ class EnvDB(BaseDB):
             stmt = stmt.where(DBObject.status == status)
         if split is not None:
             # Need to join up to parent for split query
-            stmt = stmt.where(DBObject.base_name.has(split=split))
+            stmt = stmt.where(DBObject.base_name.has(split=split))  # type: ignore
         if creator_id is not None:
             stmt = stmt.where(DBObject.creator_id == creator_id)
         # Do query
@@ -1273,18 +1303,18 @@ class EnvDB(BaseDB):
         if base_id is not None:
             stmt = stmt.where(DBRoom.base_id == base_id)
         if name is not None:
-            stmt = stmt.where(DBRoom.name.like(f"%{name}%"))
+            stmt = stmt.where(DBRoom.name.like(f"%{name}%"))  # type: ignore
         if description is not None:
-            stmt = stmt.where(DBRoom.description.like(f"%{description}%"))
+            stmt = stmt.where(DBRoom.description.like(f"%{description}%"))  # type: ignore
         if backstory is not None:
-            stmt = stmt.where(DBRoom.backstory.like(f"%{backstory}%"))
+            stmt = stmt.where(DBRoom.backstory.like(f"%{backstory}%"))  # type: ignore
         if indoor_status is not None:
             stmt = stmt.where(DBRoom.indoor_status == indoor_status)
         if status is not None:
             stmt = stmt.where(DBRoom.status == status)
         if split is not None:
             # Need to join up to parent for split query
-            stmt = stmt.where(DBRoom.base_name.has(split=split))
+            stmt = stmt.where(DBRoom.base_name.has(split=split))  # type: ignore
         if creator_id is not None:
             stmt = stmt.where(DBRoom.creator_id == creator_id)
         # Do query
@@ -1864,7 +1894,7 @@ class EnvDB(BaseDB):
 
     # release functionality
 
-    def scrub_creators(self, start_time: Optional[int] = None) -> int:
+    def scrub_creators(self, start_time: Optional[float] = None) -> int:
         """
         Remove creators from anything in the dataset longer than 60 days
         """
@@ -1954,7 +1984,7 @@ class EnvDB(BaseDB):
                     if len(all_data) == 0:
                         continue
                     new_conn.execute(table_obj.insert().values(all_data))
-                    new_conn.commit()
+                    new_conn.commit()  # type: ignore
 
         new_db.clear_player_graphs(scrub_all=True)
         new_db.scrub_creators(
@@ -1970,7 +2000,7 @@ class EnvDB(BaseDB):
                     graph.file_path, json_encoded=False
                 )
                 new_db.write_data_to_file(
-                    graph_data, graph.file_path, json_encoded=False
+                    graph_data, graph.file_path, json_encode=False
                 )
 
             # Copy the quests to the new DB
@@ -1981,6 +2011,6 @@ class EnvDB(BaseDB):
                 if file_path is None:
                     continue  # no quest file
                 quest_data = self.read_data_from_file(file_path, json_encoded=False)
-                new_db.write_data_to_file(quest_data, file_path, json_encoded=False)
+                new_db.write_data_to_file(quest_data, file_path, json_encode=False)
 
         return new_db

--- a/light/data_model/db/environment.py
+++ b/light/data_model/db/environment.py
@@ -252,7 +252,7 @@ class DBAgent(DBElem, SQLBase):
         str = ""
         str += self.name
         if full:
-            str += f". {self.persona} "
+            str += f". {self.persona}"
         return str.rstrip()
 
     def __repr__(self):
@@ -299,7 +299,7 @@ class DBObject(DBElem, SQLBase):
         str = ""
         str += self.name
         if full:
-            str += f". {self.physical_description} "
+            str += f". {self.physical_description}"
         return str.rstrip()
 
     def __repr__(self):

--- a/light/graph/builders/base.py
+++ b/light/graph/builders/base.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import random
+import asyncio
 from dataclasses import dataclass
 from light.data_model.db.base import DBStatus
 
@@ -226,7 +227,8 @@ class SingleSuggestionGraphBuilder(object):
         self.agents[agent_type].reset()
         msg = {"text": observation, "episode_done": True}
         self.agents[agent_type].observe(msg)
-        response = self.agents[agent_type].act()
+        loop = asyncio.get_event_loop()
+        response = await loop.run_in_executor(None, self.agents[agent_type].act)
         return response
 
     def get_description(self, txt_feat, element_type, num_results=5):

--- a/light/graph/builders/base.py
+++ b/light/graph/builders/base.py
@@ -3,34 +3,17 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-import asyncio
-import random, copy
+import random
 from dataclasses import dataclass
-from light.graph.builders.db_utils import id_is_usable
-from light.data_model.light_database import (
-    LIGHTDatabase,
-    DB_TYPE_ROOM,
-    DB_TYPE_CHAR,
-    DB_TYPE_OBJ,
-    DB_STATUS_REJECTED,
-    DB_EDGE_IN_CONTAINED,
-    DB_EDGE_EX_CONTAINED,
-    DB_EDGE_WORN,
-    DB_EDGE_WIELDED,
-    DB_EDGE_NEIGHBOR,
-)
-from light.graph.builders.base_elements import (
-    DBRoom,
-    DBObject,
-    DBCharacter,
-)
+from light.data_model.db.base import DBStatus
 
-from typing import Any, Dict, TYPE_CHECKING
+from typing import Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from light.data_model.db.environment import EnvDB, DBRoom, DBAgent, DBObject
     from light.registry.model_pool import ModelPool
-    from parlai.core.message import Message
-    from parlai.core.agents import Agent as ParlAIAgent
+    from parlai.core.message import Message  # type: ignore
+    from parlai.core.agents import Agent as ParlAIAgent  # type: ignore
 
 # Possible new entrances for add_new_random_agent
 POSSIBLE_NEW_ENTRANCES = [
@@ -47,7 +30,7 @@ POSSIBLE_NEW_ENTRANCES = [
 class GraphBuilderConfig(object):
     """Configuration options for a specific graph builder"""
 
-    pass
+    _builder: str = "base"
 
 
 class GraphBuilder(object):
@@ -56,7 +39,7 @@ class GraphBuilder(object):
     and to develop new ways, all adhering to a standard interface for
     making graphs"""
 
-    def __init__(self):
+    def __init__(self, builder_config: GraphBuilderConfig):
         """Initialize any required models you might need, parse arguments, and
         set other parameters as required to build graphs using this builder"""
         raise NotImplementedError
@@ -75,89 +58,82 @@ class DBGraphBuilder(GraphBuilder):
     the light db to find content
     """
 
-    def __init__(self, ldb, allow_blocked=False):
-        """Initialize a GraphBuilder with access to a LIGHTDatabase class"""
+    def __init__(
+        self,
+        builder_config: GraphBuilderConfig,
+        db: "EnvDB",
+        allow_blocked: bool = False,
+    ):
+        """Initialize a GraphBuilder with access to an EnvDB class"""
+        self.config = builder_config
         self.allow_blocked = allow_blocked
-        self.db = ldb
-        with self.db as open_db:
-            open_db.create_cache()
+        self.db = db
+        self.db.create_node_cache()
         self.__usable_rooms = None
         self.__usable_chars = None
         self.__usable_objects = None
 
-    def get_usable_rooms(self):
+    def get_usable_rooms(self) -> List[str]:
         """
         Return all rooms that are currently usable,
         caching the result
         """
         if self.__usable_rooms is None:
-            with self.db as ldb:
-                room_ids = [
-                    room["id"]
-                    for room in ldb.get_room()
-                    if id_is_usable(ldb, room["id"])
-                ]
-                self.__usable_rooms = room_ids
+            rooms = self.db.find_rooms()
+            if not self.allow_blocked:
+                rooms = [r for r in rooms if r.status == DBStatus.PRODUCTION]
+            self.__usable_rooms = [r.db_id for r in rooms]
         return self.__usable_rooms.copy()
 
-    def get_usable_chars(self):
+    def get_usable_chars(self) -> List[str]:
         """
         Return all chars that are currently usable,
         caching the result
         """
         if self.__usable_chars is None:
-            with self.db as ldb:
-                char_ids = [
-                    char["id"]
-                    for char in ldb.get_character()
-                    if id_is_usable(ldb, char["id"])
-                ]
-                self.__usable_chars = char_ids
+            chars = self.db.find_agents()
+            if not self.allow_blocked:
+                chars = [c for c in chars if c.status == DBStatus.PRODUCTION]
+            self.__usable_chars = [c.db_id for c in chars]
         return self.__usable_chars.copy()
 
-    def get_usable_objects(self):
+    def get_usable_objects(self) -> List[str]:
         """
         Return all objects that are currently usable,
         caching the result
         """
         if self.__usable_objects is None:
-            with self.db as ldb:
-                obj_ids = [
-                    obj["id"]
-                    for obj in ldb.get_object()
-                    if id_is_usable(ldb, obj["id"])
-                ]
-                self.__usable_objects = obj_ids
+            objs = self.db.find_objects()
+            if not self.allow_blocked:
+                objs = [o for o in objs if o.status == DBStatus.PRODUCTION]
+            self.__usable_objects = [o.db_id for o in objs]
         return self.__usable_objects.copy()
 
-    def get_room_from_id(self, room_id):
+    def get_room_from_id(self, room_id: str) -> Optional["DBRoom"]:
         """Get a DBRoom representation for a room in the database by that
         room's database id. Return None if no match
         """
         if not room_id in self.get_usable_rooms():
             return None
-        room = DBRoom(self.db, room_id, cache=self.db.cache)
-        return room
+        return self.db.get_room(room_id)
 
-    def get_obj_from_id(self, object_id):
+    def get_obj_from_id(self, object_id) -> Optional["DBObject"]:
         """Get a DBObject representation for an object in the database by that
         object's database id. Return None if no match
         """
         if not object_id in self.get_usable_objects():
             return None
-        obj = DBObject(self.db, object_id, cache=self.db.cache)
-        return obj
+        return self.db.get_object(object_id)
 
-    def get_char_from_id(self, char_id):
-        """Get a DBCharacter representation for a char in the database by that
+    def get_char_from_id(self, char_id) -> Optional["DBAgent"]:
+        """Get a DBAgent representation for a char in the database by that
         char's database id. Return None if no match
         """
         if not char_id in self.get_usable_chars():
             return None
-        char = DBCharacter(self.db, char_id, cache=self.db.cache)
-        return char
+        return self.db.get_agent(char_id)
 
-    def get_random_room(self):
+    def get_random_room(self) -> Optional["DBRoom"]:
         """Get a random room from the database."""
         room_ids = self.get_usable_rooms()
         if not len(room_ids):
@@ -166,7 +142,7 @@ class DBGraphBuilder(GraphBuilder):
         room = self.get_room_from_id(room_id)
         return room
 
-    def get_random_char(self):
+    def get_random_char(self) -> Optional["DBAgent"]:
         """Get a random char from the database."""
         char_ids = self.get_usable_chars()
         if not len(char_ids):
@@ -175,7 +151,7 @@ class DBGraphBuilder(GraphBuilder):
         char = self.get_char_from_id(char_id)
         return char
 
-    def get_random_obj(self):
+    def get_random_obj(self) -> Optional["DBObject"]:
         """Get a random obj from the database."""
         obj_ids = self.get_usable_objects()
         if not len(obj_ids):
@@ -184,42 +160,50 @@ class DBGraphBuilder(GraphBuilder):
         obj = self.get_obj_from_id(obj_id)
         return obj
 
-    def get_room_categories(self):
+    def get_room_categories(self) -> List[str]:
         """Return a list of the possible categories that rooms can be"""
-        with self.db as ldb:
-            base_room_name_list = [
-                br["name"] for br in ldb.get_base_room() if id_is_usable(ldb, br["id"])
+        room_name_list = self.db.find_room_names()
+        if not self.allow_blocked:
+            room_name_list = [
+                r for r in room_name_list if r.status == DBStatus.PRODUCTION
             ]
-        return base_room_name_list
+        return [r.name for r in room_name_list]
 
-    def roomfeats_to_id(self, text_feats):
+    def roomfeats_to_id(self, text_feats) -> Optional[str]:
         """Return db_id of a room from text features"""
-        features = text_feats.split(".")
-        with self.db as ldb:
-            id = ldb.get_room(name=features[0])[0]["id"]
-            return id if id_is_usable(ldb, id) else None
+        features = text_feats.split(". ")
+        rooms = self.db.find_rooms(name=features[0])
+        if len(rooms) == 0:
+            return None
+        if self.allow_blocked or rooms[0].status == DBStatus.PRODUCTION:
+            return rooms[0].db_id
+        return None
 
-    def objfeats_to_id(self, text_feats):
+    def objfeats_to_id(self, text_feats) -> Optional[str]:
         """Return db_id of an object from text features"""
-        features = text_feats.split(".")
-        with self.db as ldb:
-            objs = ldb.get_object(name=features[0])
-            if len(objs) > 0:
-                id = objs[0]["id"]
-            else:
-                return None
-            return id if id_is_usable(ldb, id) else None
+        features = text_feats.split(". ", 1)
+        objs = self.db.find_objects(
+            name=features[0].strip(),
+            physical_description=features[1].strip(),
+        )
+        if len(objs) == 0:
+            return None
+        if self.allow_blocked or objs[0].status == DBStatus.PRODUCTION:
+            return objs[0].db_id
+        return None
 
-    def charfeats_to_id(self, text_feats):
+    def charfeats_to_id(self, text_feats) -> Optional[str]:
         """Return db_id of character from text features"""
-        features = text_feats.split(".")
-        with self.db as ldb:
-            chars = ldb.get_character(name=features[0])
-            if len(chars) > 0:  # Catching for failed query
-                id = chars[0]["id"]
-            else:
-                return None
-            return id if id_is_usable(ldb, id) else None
+        features = text_feats.split(". ", 1)
+        agents = self.db.find_agents(
+            name=features[0].strip(),
+            persona=features[1].strip(),
+        )
+        if len(agents) == 0:
+            return None
+        if self.allow_blocked or agents[0].status == DBStatus.PRODUCTION:
+            return agents[0].db_id
+        return None
 
 
 class SingleSuggestionGraphBuilder(object):
@@ -235,14 +219,14 @@ class SingleSuggestionGraphBuilder(object):
         """abstract method for loading models for suggestions"""
         raise NotImplementedError
 
-    async def agent_recommend(self, observation, agent_type) -> "Message":
+    async def agent_recommend(self, observation: str, agent_type: str) -> "Message":
         """Return a response when querying a specific
         type of agent and return the model response"""
         assert agent_type in self.agents, "Agent type not found in existing agents"
         self.agents[agent_type].reset()
         msg = {"text": observation, "episode_done": True}
         self.agents[agent_type].observe(msg)
-        response = await self.agents[agent_type].act()
+        response = self.agents[agent_type].act()
         return response
 
     def get_description(self, txt_feat, element_type, num_results=5):

--- a/light/graph/builders/one_room_builder.py
+++ b/light/graph/builders/one_room_builder.py
@@ -7,60 +7,43 @@
 from light.registry.models.starspace_model import MapStarspaceModelConfig
 from light.world.world import World, WorldConfig
 from light.graph.structured_graph import OOGraph
+from light.registry.model_pool import ModelTypeName
 from light.graph.builders.base import (
     DBGraphBuilder,
+    GraphBuilderConfig,
     SingleSuggestionGraphBuilder,
 )
-from light.data_model.light_database import (
-    DB_EDGE_IN_CONTAINED,
-    DB_EDGE_CONTAINED_IN,
-    DB_EDGE_WORN,
-    DB_EDGE_WIELDED,
-    DB_EDGE_NEIGHBOR,
-    DB_TYPE_ROOM,
-    DB_TYPE_OBJ,
-    DB_TYPE_CHAR,
-    DB_TYPE_CHAR,
-    DB_TYPE_OBJ,
-    DB_TYPE_ROOM,
-)
-from light.graph.builders.base_elements import (
-    DBRoom,
+from light.data_model.db.environment import (
+    EnvDB,
+    DBElem,
+    DBAgent,
     DBObject,
-    DBCharacter,
+    DBRoom,
+    DBEdgeType,
 )
 
 import os
 import random
-import copy
 import time
 import asyncio
 
 from dataclasses import dataclass, field
-from omegaconf import MISSING, DictConfig
-from typing import TYPE_CHECKING
+from omegaconf import MISSING, DictConfig  # type: ignore
+from typing import Dict, Any, List, Optional, Tuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from light.data_model.light_database import LIGHTDatabase
     from light.registry.model_pool import ModelPool
+    from light.graph.elements.graph_nodes import (
+        GraphNode,
+        GraphObject,
+        GraphAgent,
+        GraphRoom,
+    )
 
-MAX_EXTRA_AGENTS_PER_ROOM = 2
-INV_DIR = {"east": "west", "west": "east", "north": "south", "south": "north"}
-NEIGHBOR = DB_EDGE_NEIGHBOR
-WEARING = DB_EDGE_WORN
-WIELDING = DB_EDGE_WIELDED
-WEARING = DB_EDGE_IN_CONTAINED
-CONTAINING = DB_EDGE_IN_CONTAINED
-CONTAINED_BY = DB_EDGE_CONTAINED_IN
-CHAR_CONTAINING = DB_EDGE_IN_CONTAINED + " char"
-RELATIONSHIP_TYPES = [
-    NEIGHBOR,
-    WIELDING,
-    WEARING,
-    CONTAINING,
-    CONTAINED_BY,
-    CHAR_CONTAINING,
-]
+ROOM_TYPE = "room"
+AGENT_TYPE = "agent"
+OBJECT_TYPE = "object"
+
 POSSIBLE_NEW_ENTRANCES = [
     "somewhere you can't see",
     "an undiscernable place",
@@ -72,8 +55,7 @@ POSSIBLE_NEW_ENTRANCES = [
 
 
 @dataclass
-class OneRoomChatBuilderConfig:  # BuilderConfig():
-    # TODO create builder config parent
+class OneRoomChatBuilderConfig(GraphBuilderConfig):
     model_loader_config: MapStarspaceModelConfig = MapStarspaceModelConfig()
     suggestion_type: str = field(
         default="model",
@@ -95,11 +77,6 @@ class OneRoomChatBuilderConfig:  # BuilderConfig():
             )
         },
     )
-    # TODO move to elsewhere
-    light_db_file: str = field(
-        default="/checkpoint/light/data/database3.db",
-        metadata={"help": ("specific path for light database")},
-    )
 
 
 class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
@@ -107,34 +84,30 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
 
     def __init__(
         self,
-        ldb: "LIGHTDatabase",  # LIGHT database, TODO replace with EnvDB
+        builder_config: "OneRoomChatBuilderConfig",  # Configuration for this builder
+        db: "EnvDB",
         model_pool: "ModelPool",  # Models this builder can use
-        builder_config: "DictConfig",  # Configuration for this builder
-        graph_opt=None,
+        world_opt: Optional[WorldConfig] = None,
     ):
         """Initializes required models and parameters for this graph builder"""
-        self.graph_opt = {} if graph_opt is None else graph_opt
+        self.world_opt = WorldConfig() if world_opt is None else world_opt
+        self.world_opt.graph_builder = self
 
         # Setup correct path
-        self.db_path = builder_config.get("light_db_file")
-        self.dpath = os.path.expanduser("~/ParlAI/data/light_maps/")
-        model_path = opt.get("model_path")
-        if model_path is None:
-            model_path = opt.get("light_model_root")
-        self.model_path = model_path
-        DBGraphBuilder.__init__(self, ldb)
+        DBGraphBuilder.__init__(self, builder_config, db)
         SingleSuggestionGraphBuilder.__init__(self, model_pool=model_pool)
+        self.config: "OneRoomChatBuilderConfig" = builder_config
 
         self.load_models()
         self.use_best_match = builder_config.use_best_match_model
         self.suggestion_type = builder_config.suggestion_type
         # Cache for retrieved room/ char/ obj dicts from the database
-        self.roomid_to_feats = {}
-        self.feats_to_roomid = {}
-        self.objid_to_feats = {}
-        self.feats_to_objid = {}
-        self.charid_to_feats = {}
-        self.feats_to_charid = {}
+        self.roomid_to_feats: Dict[str, str] = {}
+        self.feats_to_roomid: Dict[str, str] = {}
+        self.objid_to_feats: Dict[str, str] = {}
+        self.feats_to_objid: Dict[str, str] = {}
+        self.charid_to_feats: Dict[str, str] = {}
+        self.feats_to_charid: Dict[str, str] = {}
         # paramter to control the hybridity of the model
         self.prob_skip_ex_objects = builder_config.hybridity_prob
         self.prob_skip_ex_char = builder_config.hybridity_prob
@@ -145,18 +118,21 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
 
     def load_models(self) -> None:
         """Load starspace models for building the map"""
-        # self.model_pool.register_model(self.config.model_loader_config, "map_starspace")
+        if not self.model_pool.has_model(ModelTypeName.CONNECTIONS):
+            self.model_pool.register_model(
+                self.config.model_loader_config, [ModelTypeName.CONNECTIONS]
+            )
         self.agents["room"] = self.model_pool.get_model(
-            "map_starspace", {"target_type": "room"}
+            ModelTypeName.CONNECTIONS, {"target_type": "room"}
         )
         self.agents["object"] = self.model_pool.get_model(
-            "map_starspace", {"target_type": "object"}
+            ModelTypeName.CONNECTIONS, {"target_type": "object"}
         )
         self.agents["character"] = self.model_pool.get_model(
-            "map_starspace", {"target_type": "character"}
+            ModelTypeName.CONNECTIONS, {"target_type": "character"}
         )
 
-    def _props_from_obj(self, obj):
+    def _props_from_obj(self, obj: DBObject) -> Dict[str, Any]:
         """Given a DBObject representing an object in the world, extract the
         required props to create that object in the world
         """
@@ -166,7 +142,7 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
             "size": 1,
             "food_energy": 0,
             "value": 1,
-            "desc": obj.description,
+            "desc": obj.physical_description,
         }
         if obj.is_surface > 0.5:
             props["container"] = True
@@ -203,8 +179,8 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
 
         return props
 
-    def _props_from_char(self, char):
-        """Given a dict representing a character in the world, extract the
+    def _props_from_char(self, char: DBAgent) -> Dict[str, Any]:
+        """Given a DBAgent representing a character in the world, extract the
         required props to create that object in the world
         """
         use_classes = ["agent"]
@@ -216,8 +192,7 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
             "food_energy": 1,
             "aggression": 0,
             "speed": 5,
-            "char_type": char.char_type,
-            "desc": char.desc,
+            "desc": char.physical_description,
             "persona": char.persona,
         }
         props["classes"] = use_classes
@@ -228,10 +203,8 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
             props["is_plural"] = False
         return props
 
-    def _heuristic_name_cleaning(self, use_desc):
+    def _heuristic_name_cleaning(self, use_desc: str) -> str:
         """Remove some artifacts of bad data collection."""
-        # TODO deprecate after initial version of LIGHTDatabase is completed
-        # with this stuff already cleaned up.
         if use_desc.lower().startswith("a "):
             use_desc = use_desc[2:]
         if use_desc.lower().startswith("an "):
@@ -240,14 +213,19 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
             use_desc = use_desc[4:]
         return use_desc
 
-    async def add_object_to_graph(self, g, obj, container_node, extra_props=None):
+    async def add_object_to_graph(
+        self,
+        g: OOGraph,
+        obj: DBObject,
+        container_node: "GraphNode",
+        extra_props: Optional[Dict[str, Any]] = None,
+    ) -> Optional["GraphNode"]:
         """Adds a particular DBObject to the given OOgraph, adding to the specific
         container node. Returns the newly created object node"""
         if obj is None:
             return None
         if extra_props is None:
             extra_props = {}
-        obj.description = obj.description.capitalize()
         if obj.is_plural == 1:
             if extra_props.get("not_gettable", False) is not True:
                 # TODO: figure out making plurals work better
@@ -261,26 +239,31 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
         if self._name_not_in_graph(g, obj.name):
             obj_node = self._add_object_to_graph(g, obj, container_node)
             if obj_node.container and self.suggestion_type != "human":
+                # Currently only adding one layer of contained object of an object
                 print(
                     "Adding CONTAINED objects to CONTAINER object to ",
                     obj.name,
                     obj.db_id,
                 )
                 contained_objs = await self.get_contained_items(
-                    obj.db_id, DB_TYPE_OBJ, 3
-                )[1:]
+                    obj.db_id, OBJECT_TYPE, 3
+                )
                 for o in contained_objs:
                     if self._name_not_in_graph(g, o.name):
                         self._add_object_to_graph(g, o, obj_node)
-                # TODO: Currently only adding one layer of contained object of an object
-                # Check if we want to add more layers
             return obj_node
 
-    def _name_not_in_graph(self, g, name):
+    def _name_not_in_graph(self, g: "OOGraph", name: str) -> bool:
         """check if a node with a certain name is contained in the graph"""
         return name not in [n.name for n in g.all_nodes.values()]
 
-    def _add_object_to_graph(self, g, obj, container_node, extra_props=None):
+    def _add_object_to_graph(
+        self,
+        g: "OOGraph",
+        obj: "DBObject",
+        container_node: "GraphNode",
+        extra_props: Optional[Dict[str, Any]] = None,
+    ) -> "GraphObject":
         """Helper for add_object_to_graph to reduce redundancy"""
         if extra_props is None:
             extra_props = {}
@@ -293,13 +276,17 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
 
         # Add the object to the graph
         obj_node = g.add_object(use_desc, props, db_id=obj.db_id)
-        if obj_node.size <= container_node.contain_size:
-            obj_node.move_to(container_node)
-            return obj_node
+        obj_node.force_move_to(container_node)
+        return obj_node
 
-    async def add_new_agent_to_graph(self, g, char, room_node):
-        """Add the given DBcharacter  to the given room (room_node) in the
-        given OOFraph. Return the new agent node on success, and None on failure"""
+    async def add_new_agent_to_graph(
+        self,
+        g: "OOGraph",
+        char: "DBAgent",
+        room_node: "GraphRoom",
+    ) -> Optional["GraphAgent"]:
+        """Add the given DBAgent to the given room (room_node) in the
+        given OOGraph. Return the new agent node on success, and None on failure"""
         if char is None:
             return None
         if "is_banned" in vars(char):
@@ -322,26 +309,33 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
         objs = {}
         if self.suggestion_type != "model":
             # For the case of only using human recs and hybrid
-            for obj in char.carrying_objects["db"]:
+            for obj_edge in char.node_edges:
                 # Only use the database id objects, as add object to graph takes an obj_id
-                objs[obj] = "carrying"
-            for obj in char.wearing_objects["db"]:
-                objs[obj] = "equipped"
-            for obj in char.wielding_objects["db"]:
-                objs[obj] = "equipped"
+                if obj_edge.edge_type in [
+                    DBEdgeType.WEARING,
+                    DBEdgeType.MAY_WEAR,
+                    DBEdgeType.WIELDING,
+                    DBEdgeType.MAY_WIELD,
+                ]:
+                    objs[obj_edge.child_id] = "equipped"
+                elif obj_edge.edge_type in [
+                    DBEdgeType.CONTAINS,
+                    DBEdgeType.MAY_CONTAIN,
+                ]:
+                    objs[obj_edge.child_id] = "carrying"
         elif self.suggestion_type == "model":
             objs = {
                 obj.db_id: (
                     "equipped" if obj.is_wearable or obj.is_weapon else "carrying"
                 )
-                for obj in await self.get_contained_items(char.db_id, DB_TYPE_CHAR)
+                for obj in await self.get_contained_items(char.db_id, AGENT_TYPE)
             }
         if self.suggestion_type == "hybrid" and len(objs) == 0:
             objs = {
                 obj.db_id: (
                     "equipped" if obj.is_weapon or obj.is_wearable else "carrying"
                 )
-                for obj in await self.get_contained_items(char.db_id, DB_TYPE_CHAR, 2)
+                for obj in await self.get_contained_items(char.db_id, AGENT_TYPE, 2)
             }
 
         for obj in objs:
@@ -353,50 +347,56 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
                     obj_node.set_prop("equipped", True)
         return agent_node
 
-    async def add_random_new_agent_to_graph(self, world):
+    async def add_random_new_agent_to_graph(self, world: World):
         """Add a random agent to the OOGraph at a random room node"""
         raise Exception("There shouldn't be any random additions")
 
-    async def add_neighbors(self, room):
+    async def add_neighbors(self, room: "DBRoom") -> List["DBRoom"]:
         """Try to add all possible exits to a given room"""
         if self.use_best_match:
-            neighbors = room.get_text_edges(DB_EDGE_NEIGHBOR)
+            neighbors = room.node_edges
+            neighbors = [
+                n.child for n in neighbors if n.edge_type == DBEdgeType.NEIGHBOR
+            ]
         else:
             # Not using best match model but the starspace model for model prediction
-            neighbors = [
-                e.setting
-                for e in await self.get_neighbor_rooms(
-                    room_id=room.db_id, banned_rooms=[]
-                )
-            ]
-        return neighbors
+            neighbors = await self.get_neighbor_rooms(
+                room_id=room.db_id, banned_rooms=[]
+            )
+        return neighbors  # type: ignore
 
     ##########For best match model###################
-    async def get_similar_element(self, txt_feats, element_type):
+    async def get_similar_element(
+        self,
+        txt_feats: str,
+        element_type: str,
+    ):
         """Given a text feature, and the corresponding Database type
         return an DBElement of the DB type"""
         agent_type = None
         banned_items = {}
         feats_to_id = None
         get_x_from_id = None
-        if element_type == DB_TYPE_ROOM:
+        if element_type == ROOM_TYPE:
             agent_type = "room"
             banned_items = self.banned_rooms
             feats_to_id = self.roomfeats_to_id
             get_x_from_id = self.get_room_from_id
-        elif element_type == DB_TYPE_OBJ:
+        elif element_type == OBJECT_TYPE:
             agent_type = "object"
             feats_to_id = self.objfeats_to_id
             get_x_from_id = self.get_obj_from_id
-        elif element_type == DB_TYPE_CHAR:
+        elif element_type == AGENT_TYPE:
             agent_type = "character"
             feats_to_id = self.charfeats_to_id
             get_x_from_id = self.get_char_from_id
+        else:
+            raise Exception(f"Invalid element type: {element_type}")
         if agent_type is not None:
             self.agents[agent_type].reset()
             msg = {"text": txt_feats, "episode_done": True}
             self.agents[agent_type].observe(msg)
-            response = await self.agents[agent_type].act()
+            response = self.agents[agent_type].act()
             ind = 0
             while ind < len(response["text_candidates"]):
                 key = response["text_candidates"][ind]
@@ -409,21 +409,26 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
     async def get_similar_room(self, txt_feats):
         """Find a similar room to the text room given
         based on a starspace prediction"""
-        return await self.get_similar_element(txt_feats, DB_TYPE_ROOM)
+        return await self.get_similar_element(txt_feats, ROOM_TYPE)
 
     async def get_similar_object(self, txt_feats):
         """Find a similar object to the text given
         based on starspace prediciton"""
-        return await self.get_similar_element(txt_feats, DB_TYPE_OBJ)
+        return await self.get_similar_element(txt_feats, OBJECT_TYPE)
 
     async def get_similar_character(self, txt_feats):
         """Find a similar object to the text given
         based on starspace prediciton"""
-        return await self.get_similar_element(txt_feats, DB_TYPE_CHAR)
+        return await self.get_similar_element(txt_feats, AGENT_TYPE)
 
     ###################################################
 
-    async def get_neighbor_rooms(self, room_id, num_results=5, banned_rooms=None):
+    async def get_neighbor_rooms(
+        self,
+        room_id: str,
+        num_results: int = 5,
+        banned_rooms: Optional[List[str]] = None,
+    ) -> List[DBRoom]:
         """get prediction of neighbor room with StarSpaceModel, return DBRoom Object """
         if banned_rooms is None:
             banned_rooms = [room_id]
@@ -441,20 +446,24 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
                 rind = self.feats_to_roomid[key]
             else:
                 rind = self.roomfeats_to_id(key)
-            if rind not in banned_rooms:
-                results.append(self.get_room_from_id(rind))
+            if rind is not None and rind not in banned_rooms:
+                res = self.get_room_from_id(rind)
+                if res is not None:
+                    results.append(res)
             ind = ind + 1
             if len(response["text_candidates"]) <= ind:
                 if len(results) == 0:
-                    return None
+                    return []
                 else:
                     return results
         return results
 
-    async def get_graph_from_quest(self, quest):
+    async def get_graph_from_quest(
+        self, quest: Dict[str, Any]
+    ) -> Tuple["OOGraph", "World"]:
         graph_json = quest["data"]["graph"]
         g = OOGraph.from_json(graph_json)
-        world = World(WorldConfig(opt=self.graph_opt, graph_builder=self))
+        world = World(self.world_opt)
         world.oo_graph = g
 
         base_room = list(g.rooms.values())[0]
@@ -467,11 +476,11 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
             if neighbor_room is None:
                 continue
             g.add_room(
-                neighbor_room.setting,
+                neighbor_room.name,
                 {
                     "room": True,
                     "desc": neighbor_room.description,
-                    "extra_desc": neighbor_room.background,
+                    "extra_desc": neighbor_room.backstory,
                     "size": 2000,  # TODO turk room sizes
                     "contain_size": 2000,  # TODO turk room sizes
                     "name_prefix": "the",
@@ -490,15 +499,18 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
         if location is None:
             set_room = self.get_random_room()
         else:
-            set_room = self.get_room_from_id(self.roomfeats_to_id(location))
+            rid = self.roomfeats_to_id(location)
+            assert rid is not None, f"Provided location not found {location}"
+            set_room = self.get_room_from_id(rid)
 
-        g = OOGraph(self.graph_opt)
+        assert set_room is not None, "No room found!"
+        g = OOGraph()
         room_node = g.add_room(
-            set_room.setting,
+            set_room.name,
             {
                 "room": True,
                 "desc": set_room.description,
-                "extra_desc": set_room.background,
+                "extra_desc": set_room.backstory,
                 "size": 2000,  # TODO turk room sizes
                 "contain_size": 2000,  # TODO turk room sizes
                 "name_prefix": "the",
@@ -510,16 +522,19 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
         set_room.g_id = room_node.node_id
 
         possible_chars = await self.get_contained_characters(
-            room_id=set_room.db_id, num_results=5
+            room_id=set_room.db_id, num_results=15
         )
-        if "db" in set_room.ex_characters:
-            for char_id in set_room.ex_characters["db"]:
-                char = self.get_char_from_id(char_id)
-                possible_chars.append(char)
-        if "db" in set_room.in_characters:
-            for char_id in set_room.in_characters["db"]:
-                char = self.get_char_from_id(char_id)
-                possible_chars.append(char)
+        room_edges = set_room.node_edges
+        # add characters from the room
+        possible_chars.extend(
+            [  # type: ignore
+                c.child
+                for c in room_edges
+                if c.edge_type
+                in [DBEdgeType.CONTAINED_IN, DBEdgeType.MAY_BE_CONTAINED_IN]
+                and isinstance(c.child, DBAgent)
+            ]
+        )
 
         if player is None:
             player_char = random.choice(possible_chars)
@@ -548,38 +563,48 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
                     g, partner_char, room_node
                 )
 
-        if "db" in set_room.ex_objects:
-            for item_id in set_room.ex_objects["db"]:
-                if random.random() > self.prob_skip_ex_objects:
-                    continue
-                obj = self.get_obj_from_id(item_id)
-                if obj is not None:
-                    self.add_object_to_graph(g, obj, room_node)
-        if "db" in set_room.in_objects:
-            for item_id in set_room.in_objects["db"]:
-                obj = self.get_obj_from_id(item_id)
-                props = {}
-                if obj is not None:
-                    self.add_object_to_graph(g, obj, room_node, props)
+        in_objs = [  # type: ignore
+            c.child
+            for c in room_edges
+            if c.edge_type in [DBEdgeType.CONTAINED_IN]
+            and isinstance(c.child, DBObject)
+        ]
+        ex_objs = [  # type: ignore
+            c.child
+            for c in room_edges
+            if c.edge_type in [DBEdgeType.MAY_BE_CONTAINED_IN]
+            and isinstance(c.child, DBObject)
+        ]
+
+        for obj in ex_objs:
+            if random.random() > self.prob_skip_ex_objects:
+                continue
+            if obj is not None:
+                await self.add_object_to_graph(g, obj, room_node)
+        for obj in in_objs:
+            props = {}
+            if obj is not None:
+                await self.add_object_to_graph(g, obj, room_node, props)
         if self.suggestion_type == "model":
             predicted_objects = await self.get_contained_items(
-                container_id=set_room.db_id, container_type=DB_TYPE_ROOM
+                container_id=set_room.db_id, container_type=ROOM_TYPE
             )
             for o in predicted_objects:
                 if o is not None:
                     room_node = g.get_node(set_room.g_id)
-                    self.add_object_to_graph(g, o, room_node)
+                    assert room_node is not None
+                    await self.add_object_to_graph(g, o, room_node)
 
         neighbors = await self.get_neighbor_rooms(set_room.db_id)
         for neighbor_room in neighbors:
             if neighbor_room is None:
                 continue
             g.add_room(
-                neighbor_room.setting,
+                neighbor_room.name,
                 {
                     "room": True,
                     "desc": neighbor_room.description,
-                    "extra_desc": neighbor_room.background,
+                    "extra_desc": neighbor_room.backstory,
                     "size": 2000,  # TODO turk room sizes
                     "contain_size": 2000,  # TODO turk room sizes
                     "name_prefix": "the",
@@ -589,11 +614,16 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
                 db_id=neighbor_room.db_id,
             )
 
-        world = World(WorldConfig(opt=self.graph_opt, graph_builder=self))
+        world = World(WorldConfig(graph_builder=self))
         world.oo_graph = g
         return g, world
 
-    async def get_constrained_graph(self, location=None, player=None, num_partners=1):
+    async def get_constrained_graph(
+        self,
+        location: Optional[str] = None,
+        player: Optional[str] = None,
+        num_partners: int = 1,
+    ) -> Tuple[Optional["OOGraph"], Optional["World"]]:
         """Take a few attempts to get the graph meeting the given constraints"""
         attempts = 9
         graph = None
@@ -607,19 +637,25 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
                     num_partners=num_partners,
                 )
             except Exception as _e:
-                print(_e)
+                import traceback
+
+                traceback.print_exc()
                 attempts -= 1
         return graph, world
 
-    async def get_graph(self):
+    async def get_graph(self) -> Tuple[Optional["OOGraph"], Optional["World"]]:
         """Construct a graph using the grid created with build_world after
         selecting new characters and objects to place within.
         """
         return await self.get_constrained_graph(None, None, num_partners=1)
 
     async def get_contained_items(
-        self, container_id, container_type, num_results=5, banned_items=None
-    ):
+        self,
+        container_id: str,
+        container_type: str,
+        num_results: int = 5,
+        banned_items: Optional[List[str]] = None,
+    ) -> List[DBObject]:
         """
         Get prediction of contained items from StarSpace model
         given a container's database id and container type.
@@ -627,22 +663,24 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
         if banned_items is None:
             banned_items = []
         must_be_gettable = True
-        if container_type == DB_TYPE_ROOM:
+        if container_type == ROOM_TYPE:
             must_be_gettable = False
             if container_id in self.roomid_to_feats:
                 txt_feats = self.roomid_to_feats[container_id]
             else:
                 txt_feats = self.get_text_features(self.get_room_from_id(container_id))
-        elif container_type == DB_TYPE_OBJ:
+        elif container_type == OBJECT_TYPE:
             if container_id in self.objid_to_feats:
                 txt_feats = self.objid_to_feats[container_id]
             else:
                 txt_feats = self.get_text_features(self.get_obj_from_id(container_id))
-        elif container_type == DB_TYPE_CHAR:
+        elif container_type == AGENT_TYPE:
             if container_id in self.charid_to_feats:
                 txt_feats = self.charid_to_feats[container_id]
             else:
                 txt_feats = self.get_text_features(self.get_char_from_id(container_id))
+        else:
+            raise Exception(f"Improper container type given: {container_type}")
         response = await self.agent_recommend(txt_feats, "object")
         ind = 0
         results = []
@@ -654,14 +692,17 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
             oid = self.objfeats_to_id(key)
             if oid is not None and oid not in banned_items:
                 obj = self.get_obj_from_id(oid)
-                if obj.is_gettable or not must_be_gettable:
+                if obj is not None and (obj.is_gettable or not must_be_gettable):
                     results.append(obj)
             ind = ind + 1
         return results
 
     async def get_contained_characters(
-        self, room_id, num_results=5, banned_characters=None
-    ):
+        self,
+        room_id: str,
+        num_results: int = 5,
+        banned_characters: Optional[List[str]] = None,
+    ) -> List[DBAgent]:
         """ Get prediction of contained characters in given room_id from StarSpace model."""
         if banned_characters is None:
             banned_characters = []
@@ -683,16 +724,18 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
                 continue
             cind = self.charfeats_to_id(key)
             if cind is not None and cind not in banned_characters:
-                results.append(self.get_char_from_id(cind))
+                res = self.get_char_from_id(cind)
+                if res is not None:
+                    results.append(res)
             ind = ind + 1
             if len(response["text_candidates"]) <= ind:
                 if len(results) == 0:
-                    return None
+                    return []
                 else:
                     return results
         return results
 
-    def get_text_features(self, c, full=False):
+    def get_text_features(self, c: DBElem, full: bool = False):
         """Return text feature given a candidate and return and cache the text feature"""
         feat = ""
         if type(c) is DBRoom:
@@ -703,8 +746,40 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
             self.feats_to_objid[feat] = c.db_id
             feat = c.object_features(full)
             self.objid_to_feats[c.db_id] = feat
-        if type(c) is DBCharacter:
+        if type(c) is DBAgent:
             feat = c.character_features(full)
             self.feats_to_charid[feat] = c.db_id
             self.charid_to_feats[c.db_id] = feat
         return feat
+
+
+if __name__ == "__main__":
+    import os
+    from light import LIGHT_DIR
+    from light.data_model.db.base import LightLocalDBConfig
+    from light.registry.model_pool import ModelPool
+
+    print("Generating a random starspace map")
+
+    opt_path = os.path.join(
+        LIGHT_DIR, "light/registry/models/config/baseline_starspace.opt"
+    )
+
+    config = OneRoomChatBuilderConfig(
+        model_loader_config=MapStarspaceModelConfig(opt_file=opt_path)
+    )
+    env_db = EnvDB(LightLocalDBConfig(file_root=os.path.join(LIGHT_DIR, "prod_db")))
+
+    map_dir = os.path.join(LIGHT_DIR, "scripts", "examples", "maps")
+    while True:
+        builder = OneRoomChatBuilder(config, env_db, ModelPool())
+        graph, world = asyncio.run(builder.get_graph())
+        assert graph is not None, "Graph failed to build"
+        output_name = input("\nProvide output name:\n>") + ".json"
+        output_dir = os.path.join(map_dir, output_name)
+        with open(output_dir, "w+") as json_file:
+            json_file.write(graph.to_json())
+        print(f"Written to {output_dir}")
+        if input("Another? (y to continue)") != "y":
+            break
+    print("Bye!")

--- a/light/graph/builders/one_room_builder.py
+++ b/light/graph/builders/one_room_builder.py
@@ -396,7 +396,8 @@ class OneRoomChatBuilder(DBGraphBuilder, SingleSuggestionGraphBuilder):
             self.agents[agent_type].reset()
             msg = {"text": txt_feats, "episode_done": True}
             self.agents[agent_type].observe(msg)
-            response = self.agents[agent_type].act()
+            loop = asyncio.get_event_loop()
+            response = await loop.run_in_executor(None, self.agents[agent_type].act)
             ind = 0
             while ind < len(response["text_candidates"]):
                 key = response["text_candidates"][ind]

--- a/light/registry/hydra_registry.py
+++ b/light/registry/hydra_registry.py
@@ -11,9 +11,9 @@ structured configs.
 
 import os
 from os.path import abspath, dirname
-from hydra.core.config_store import ConfigStoreWithProvider
+from hydra.core.config_store import ConfigStoreWithProvider  # type: ignore
 from dataclasses import dataclass, field, fields, Field, make_dataclass
-from omegaconf import OmegaConf, MISSING, DictConfig
+from omegaconf import OmegaConf, MISSING, DictConfig  # type: ignore
 
 from light.registry.base_model_loader import ModelLoader, ModelConfig
 from light.registry.model_pool import ALL_LOADERS_LIST, ModelTypeName
@@ -29,7 +29,7 @@ LIGHT_DIR = dirname(dirname(dirname(abspath(__file__))))
 config = ConfigStoreWithProvider("light")
 
 model_type_name_default = [(x.value, ModelConfig, MISSING) for x in ModelTypeName]
-ModelPoolConfig = make_dataclass("ModelPoolConfig", model_type_name_default)
+ModelPoolConfig = make_dataclass("ModelPoolConfig", model_type_name_default)  # type: ignore
 
 
 def register_model_loader(loader: Type[ModelLoader]):
@@ -109,7 +109,7 @@ light_default_list = ["_self_", {"model_pool": "base"}]
 @dataclass
 class LightConfig:
     defaults: List[Any] = field(default_factory=lambda: light_default_list)
-    model_pool: ModelPoolConfig = ModelPoolConfig()
+    model_pool: "ModelPoolConfig" = ModelPoolConfig()  # type: ignore
     db: LightDBConfig = MISSING
     log_level: str = "info"
     model_root: str = field(

--- a/light/registry/model_pool.py
+++ b/light/registry/model_pool.py
@@ -4,8 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from dataclasses import dataclass, field
-from omegaconf import MISSING, DictConfig
+from omegaconf import MISSING, DictConfig  # type: ignore
 import asyncio
 import enum
 
@@ -24,20 +23,20 @@ from light.registry.models.starspace_model import (
     MapStarspaceModelLoader,
 )
 
-from parlai.core.agents import Agent
+from parlai.core.agents import Agent  # type: ignore
 from typing import List, Any, Union, Dict, Optional, Type, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from light.registry.hydra_registry import ModelPoolConfig
 
-ALL_LOADERS_LIST: List[ModelLoader] = [
+ALL_LOADERS_LIST: List[Type[ModelLoader]] = [
     ParlAIModelLoader,
     ParlAIPolyencoderActingScoreModelLoader,
     MapStarspaceModelLoader,
     ParlAIRemoteModelLoader,
 ]
 
-ALL_LOADERS_MAP: Dict[str, ModelLoader] = {
+ALL_LOADERS_MAP: Dict[str, Type[ModelLoader]] = {
     k.CONFIG_CLASS._loader: k for k in ALL_LOADERS_LIST
 }
 
@@ -52,6 +51,7 @@ class ModelTypeName(enum.Enum):
     GENERIC_ACTS = "generic_action"  # Models to select a next action from cands
     PARSER = "parser"  # Models to parse raw text to in-game actions
     SERVED = "served"  # Any generic served model (for ModelServer)
+    CONNECTIONS = "connections"  # A generic model to connect between graph nodes
 
 
 class ModelPool:
@@ -59,10 +59,10 @@ class ModelPool:
         self._model_loaders = {}
 
     @classmethod
-    async def get_from_config_async(cls, cfg: "ModelPoolConfig") -> "ModelPool":
+    async def get_from_config_async(cls, cfg: "ModelPoolConfig") -> "ModelPool":  # type: ignore
         """Initialize a ModelPool with models in the given ModelPoolConfig"""
         model_pool = cls()
-        models_to_load: Dict[str, ModelConfig] = {}
+        models_to_load: Dict[ModelTypeName, ModelConfig] = {}
         for model_type_name in ModelTypeName:
             model_type = model_type_name.value
             if cfg.get(model_type, None) is not None:
@@ -76,7 +76,7 @@ class ModelPool:
         return model_pool
 
     @classmethod
-    def get_from_config(cls, cfg: "ModelPoolConfig"):
+    def get_from_config(cls, cfg: "ModelPoolConfig") -> "ModelPool":  # type: ignore
         """
         Initialize a ModelPool with models in the given ModelPoolConfig synchronously
         """

--- a/light/registry/models/config/baseline_starspace.opt
+++ b/light/registry/models/config/baseline_starspace.opt
@@ -1,6 +1,6 @@
 {
     "model": "starspace",
-    "model_file": "$LIGHT_MODEL_ROOT/starspace/angela_starspace/model4"
+    "model_file": "$LIGHT_MODEL_ROOT/starspace/angela_starspace/model4",
     "eval_candidates": "inline",
     "ignore_bad_candidates": true,
     "interactive_mode": true

--- a/light/registry/models/starspace_model.py
+++ b/light/registry/models/starspace_model.py
@@ -6,8 +6,9 @@
 
 
 from dataclasses import dataclass, field
-from parlai.core.agents import Agent
+from parlai.core.agents import Agent, create_agent_from_shared  # type: ignore
 import os
+from copy import deepcopy
 
 from typing import Optional, Dict, Any
 
@@ -41,24 +42,29 @@ class MapStarspaceModelLoader(ParlAIModelLoader):
             opt = deepcopy(use_shared["opt"])
             opt.update(overrides)
             use_shared["opt"] = opt
+        else:
+            opt = {}
+            if overrides is not None:
+                opt.update(overrides)
 
         if opt["target_type"] == "room":
             opt["fixed_candidates_file"] = os.path.join(
-                self.config.resource_path, "/room_full_cands.txt"
+                self.config.resource_path, "room_full_cands.txt"
             )
-        elif opt["target_type"] == "agent":
+        elif opt["target_type"] in ["agent", "character"]:
             opt["fixed_candidates_file"] = os.path.join(
-                self.config.resource_path, "/character_full_cands.txt"
+                self.config.resource_path, "character_full_cands.txt"
             )
         elif opt["target_type"] == "object":
             opt["fixed_candidates_file"] = os.path.join(
-                self.config.resource_path, "/object_full_cands.txt"
+                self.config.resource_path, "object_full_cands.txt"
             )
         else:
             raise NotImplementedError(
                 f"Given starspace target type {opt['target_type']} not implemented"
             )
 
+        print(self.config.resource_path, opt["fixed_candidates_file"])
         opt["override"]["fixed_candidates_file"] = opt["fixed_candidates_file"]
         model = create_agent_from_shared(use_shared)
         return self.before_return_model(model)


### PR DESCRIPTION
**Patch description**
As titled, this focuses on making `OneRoomGraphBuilder` work under the new setup. Doing so required finally updating a huge portion of the `GraphBuilder` stack to work with the `EnvDB`. May need to be updated to use correct local paths.

While going through, I added a bunch of typing upgrades to make LIGHT a little more maintainable in the future.

**Testing steps**
```bash
>> python light/graph/builders/one_room_builder.py 
Generating a random starspace map
14:30:19 | No model with opt yet at: $LIGHT_MODEL_ROOT/starspace/angela_starspace/model4(.opt)
14:30:19 | creating StarspaceAgent
/Users/jju/miniconda3/envs/py38/lib/python3.8/site-packages/torch/nn/_reduction.py:42: UserWarning: size_average and reduce args will be deprecated, please use reduction='sum' instead.
  warnings.warn(warning.format(ret))
/Users/jju/ParlAI/data/light_maps/ /Users/jju/ParlAI/data/light_maps/room_full_cands.txt
14:30:19 | loaded candidates
/Users/jju/ParlAI/data/light_maps/ /Users/jju/ParlAI/data/light_maps/object_full_cands.txt
14:30:19 | loaded candidates
/Users/jju/ParlAI/data/light_maps/ /Users/jju/ParlAI/data/light_maps/character_full_cands.txt
14:30:19 | loaded candidates
Warning - no magic file at /scratch/light/data/magic.db, skipping!
[ loaded 0 magic items]

Provide output name:
>teststarspace
Written to /Users/jju/LIGHT/scripts/examples/maps/teststarspace.json
Another? (y to continue)n
Bye!
```
